### PR TITLE
overload setPosition to add coordinates directly #28

### DIFF
--- a/src/main/java/com/markit/api/AbstractWatermarkService.java
+++ b/src/main/java/com/markit/api/AbstractWatermarkService.java
@@ -109,6 +109,13 @@ public abstract class AbstractWatermarkService<Service, WatermarkBuilder, TextBa
         return (PositionStepBuilder) this;
     }
 
+    public PositionStepBuilder position(WatermarkPosition watermarkPosition, int x, int y) {
+        Objects.requireNonNull(watermarkPosition);
+        currentWatermark.setPosition(watermarkPosition);
+        currentWatermark.adjustPosition(x, y);
+        return (PositionStepBuilder) this;
+    }
+
     public PositionStepBuilder verticalSpacing(int spacing) {
         currentWatermark.setVerticalSpacing(spacing);
         return (PositionStepBuilder) this;

--- a/src/main/java/com/markit/api/image/WatermarkImageService.java
+++ b/src/main/java/com/markit/api/image/WatermarkImageService.java
@@ -1,11 +1,11 @@
 package com.markit.api.image;
 
-import com.markit.api.positioning.WatermarkPosition;
-
-import java.awt.*;
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.nio.file.Path;
+
+import com.markit.api.positioning.WatermarkPosition;
 
 /**
  * Watermark Service for applying watermarks to images
@@ -98,6 +98,15 @@ public interface WatermarkImageService {
          * @see WatermarkPosition
          */
         WatermarkPositionStepBuilder position(WatermarkPosition watermarkPosition);
+
+        /**
+         * Defines the position of the watermark on the file directly with x and y coordinates
+         * 
+         * @param watermarkPosition The position to place the watermark (e.g., CENTER, CORNER)
+         * @param x The direct x-axis offset of watermark
+         * @param y The direct y-axis offset of watermark
+         */
+        WatermarkPositionStepBuilder position(WatermarkPosition watermarkPosition, int x, int y);
 
         /**
          * Enables or disables the watermark based on a specific condition

--- a/src/main/java/com/markit/api/pdf/WatermarkPDFService.java
+++ b/src/main/java/com/markit/api/pdf/WatermarkPDFService.java
@@ -1,12 +1,13 @@
 package com.markit.api.pdf;
 
-import com.markit.api.positioning.WatermarkPosition;
-import com.markit.api.WatermarkingMethod;
-import org.apache.pdfbox.pdmodel.PDDocument;
-
-import java.awt.*;
+import java.awt.Color;
 import java.nio.file.Path;
 import java.util.function.Predicate;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+
+import com.markit.api.WatermarkingMethod;
+import com.markit.api.positioning.WatermarkPosition;
 
 /**
  * Watermark Service for applying watermarks to PDF files
@@ -94,6 +95,15 @@ public interface WatermarkPDFService {
          * @see WatermarkPosition
          */
         WatermarkPositionStepPDFBuilder position(WatermarkPosition watermarkPosition);
+
+        /**
+         * Defines the position of the watermark on the file directly with x and y coordinates
+         *
+         * @param watermarkPosition The position to place the watermark (e.g., CENTER, CORNER)
+         * @param x The direct x-axis offset of watermark
+         * @param y The direct y-axis offset of watermark
+         */
+        WatermarkPositionStepPDFBuilder position(WatermarkPosition watermarkPosition, int x, int y);
 
         /**
          * Sets the dpi of the watermark


### PR DESCRIPTION
add implementation of setPostition() in AbstractWatermarkService.java

- currently setPosition() with x and y coordinates just utilize adjustPosition() to place down watermarkposition.
- EXAMPLE: setPosition(CENTER, 100, 100); //this would put the position 100 pixels up and to the right of center position

many ways that this could be changed to be more accessible for users